### PR TITLE
Make network plugin a variable to enable BYOCNI installs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 .terraform/
 .vscode/
 terraform.tfstate*
+.terraform.tfstate*
 terraform.tfvars

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ An opinionated Terraform module that can be used to create and manage an AKS clu
 | <a name="input_max_nodes"></a> [max\_nodes](#input\_max\_nodes) | The maximum number of nodes in the AKS cluster. | `number` | `4` | no |
 | <a name="input_min_nodes"></a> [min\_nodes](#input\_min\_nodes) | The minimum number of nodes in the AKS cluster. | `number` | `3` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name of the AKS cluster. | `string` | n/a | yes |
+| <a name="input_network_plugin"></a> [network\_plugin](#input\_network\_plugin) | The network plugin to use (one of 'azure' or 'none'). | `string` | `"azure"` | no |
 | <a name="input_owner"></a> [owner](#input\_owner) | Your name. | `string` | n/a | yes |
 | <a name="input_paid_tier"></a> [paid\_tier](#input\_paid\_tier) | Whether to use the "Paid" AKS tier. | `bool` | `false` | no |
 | <a name="input_region"></a> [region](#input\_region) | The region in which to create the AKS cluster and associated resources. | `string` | n/a | yes |

--- a/example/aks.tf
+++ b/example/aks.tf
@@ -1,0 +1,42 @@
+// Create a resource group.
+resource "azurerm_resource_group" "arg" {
+  location = var.region
+  name     = var.name
+}
+
+// Create a network.
+module "network" {
+  source  = "Azure/network/azurerm"
+  version = "3.5.0"
+
+  address_space       = var.vpc_cidr
+  resource_group_name = basename(azurerm_resource_group.arg.id)
+  subnet_prefixes     = [var.vpc_cidr]
+  tags                = local.tags
+  vnet_name           = var.name
+}
+
+// Create the AKS cluster.
+module "aks" {
+  source = "../"
+
+  name                = var.name
+  owner               = var.owner
+  region              = var.region
+  resource_group_name = basename(azurerm_resource_group.arg.id)
+  service_cidr        = var.service_cidr
+  subnet_id           = module.network.vnet_subnets[0]
+  network_plugin      = "none"
+}
+
+// Provision the AKS cluster.
+module "provisioner" {
+  source = "git::https://github.com/isovalent/terraform-k8s-cilium.git?ref=v1.0"
+
+  cilium_helm_chart            = "cilium/cilium"
+  cilium_helm_version          = "1.12.2"
+  cilium_helm_values_file_path = "${abspath(path.module)}/cilium-helm-values.yaml"
+  cilium_namespace             = "cilium"
+  ipsec_key                    = var.ipsec_key
+  path_to_kubeconfig_file      = module.aks.path_to_kubeconfig_file
+}

--- a/example/cilium-helm-values.yaml
+++ b/example/cilium-helm-values.yaml
@@ -1,0 +1,39 @@
+aksbyocni:
+  enabled: true
+bpf:
+  masquerade: false
+enableIPv4Masquerade: false
+encryption:
+  enabled: false
+hubble:
+  enabled: true
+  listenAddress: :4244
+  metrics:
+    enabled:
+      - dns
+      - drop:sourceContext=pod-short;destinationContext=pod-short
+      - icmp
+      - port-distribution
+      - tcp
+    port: 29091
+  relay:
+    enabled: true
+  tls:
+    auto:
+      method: cronJob
+  ui:
+    enabled: true
+kubeProxyReplacement: disabled
+nodeinit:
+  enabled: true
+  restartPods: true
+nodePort:
+  enableHealthCheck: false
+prometheus:
+  enabled: true
+  port: 29090
+operator:
+  prometheus:
+    enabled: true
+    port: 6942
+tunnel: disabled

--- a/example/locals.tf
+++ b/example/locals.tf
@@ -1,0 +1,6 @@
+locals {
+  path_to_kubeconfig_file = "./${var.name}.kubeconfig" // The path to the kubeconfig file that will be created and output.
+  tags = {
+    "owner" : var.owner,
+  }
+}

--- a/example/outputs.tf
+++ b/example/outputs.tf
@@ -1,0 +1,11 @@
+output "cluster_name" {
+  value = var.name
+}
+
+output "path_to_kubeconfig_file" {
+  value = local.path_to_kubeconfig_file
+}
+
+output "resource_group_name" {
+  value = var.name
+}

--- a/example/providers.tf
+++ b/example/providers.tf
@@ -1,0 +1,7 @@
+provider "azurerm" {
+  subscription_id = var.subscription_id
+  tenant_id       = var.tenant_id
+
+  features {
+  }
+}

--- a/example/variables.tf
+++ b/example/variables.tf
@@ -1,0 +1,72 @@
+variable "ipsec_key" {
+  description = "The IPsec key to use."
+  sensitive   = true
+  default     = ""
+  type        = string
+}
+
+variable "kubernetes_version" {
+  default     = "1.22.6"
+  description = "The version of Kubernetes to use."
+  type        = string
+}
+
+variable "name" {
+  description = "The name of the AKS cluster."
+  default     = "aks-example"
+  type        = string
+}
+
+variable "max_nodes" {
+  default     = 4
+  description = "The maximum number of nodes in the AKS cluster."
+  type        = number
+}
+
+variable "min_nodes" {
+  default     = 3
+  description = "The minimum number of nodes in the AKS cluster."
+  type        = number
+
+}
+
+variable "owner" {
+  description = "Your name."
+  default     = "example run"
+  type        = string
+}
+
+variable "paid_tier" {
+  description = "Whether to use the \"Paid\" AKS tier."
+  default     = false
+  type        = bool
+}
+
+variable "region" {
+  description = "The region in which to create the AKS cluster and associated resources."
+  default     = "southcentralus"
+  type        = string
+}
+
+variable "service_cidr" {
+  default     = "10.0.0.0/16"
+  description = "The CIDR to use for 'ClusterIP' services."
+  type        = string
+}
+
+variable "subscription_id" {
+  default = "22716d91-fb67-4a07-ac5f-d36ea49d6167" // cilium-dev
+  type    = string
+}
+
+variable "tenant_id" {
+  default = "625cda75-62dd-470e-a554-7313877ff03c" // cilium-dev
+  type    = string
+}
+
+
+variable "vpc_cidr" {
+  default     = "10.240.0.0/16"
+  description = "The CIDR to use for the VPC."
+  type        = string
+}

--- a/main.tf
+++ b/main.tf
@@ -46,7 +46,7 @@ module "main" {
   net_profile_docker_bridge_cidr    = var.docker_bridge_cidr
   net_profile_dns_service_ip        = cidrhost(var.service_cidr, 10)
   net_profile_service_cidr          = var.service_cidr
-  network_plugin                    = "azure"
+  network_plugin                    = var.network_plugin
   orchestrator_version              = var.kubernetes_version
   os_disk_size_gb                   = var.root_disk_size
   private_cluster_enabled           = false

--- a/variables.tf
+++ b/variables.tf
@@ -53,6 +53,12 @@ variable "min_nodes" {
   type        = number
 }
 
+variable "network_plugin" {
+  description = "The network plugin to use (one of 'azure' or 'none')."
+  default     = "azure"
+  type        = string
+}
+
 variable "owner" {
   description = "Your name."
   type        = string


### PR DESCRIPTION
this PR turns the network plugin into a variable so you can specify "none" for BYOCNI installs.

Also adds an example for how to use this module, in a separate commit if it's not needed.