### PR TITLE
patch empty zone list return from command.

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -18,4 +18,6 @@ locals {
   tags = {
     "owner" : var.owner,
   }
+  availability_zones_output = module.availability_zones_data_source.stdout != "" ? module.availability_zones_data_source.stdout : "[]"
+
 }

--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ module "main" {
   source  = "Azure/aks/azurerm"
   version = "9.0.0"
 
-  agents_availability_zones         = sort(flatten(jsondecode(module.availability_zones_data_source.stdout)))
+  agents_availability_zones         = sort(flatten(jsondecode(local.availability_zones_output)))
   agents_max_count                  = var.max_nodes
   agents_min_count                  = var.min_nodes
   agents_pool_name                  = local.pool_name


### PR DESCRIPTION
Due to the `az` command being ran here, an empty set of data retruns as an empty string `""` instead of `[]`. 

```
│ Error: Error in function call
│ 
│   on .terraform/modules/aks/main.tf line 37, in module "main":
│   37:   agents_availability_zones         = sort(flatten(jsondecode(module.availability_zones_data_source.stdout)))
│     ├────────────────
│     │ while calling jsondecode(str)
│     │ module.availability_zones_data_source.stdout is ""
│ 
│ Call to function "jsondecode" failed: EOF.
```

