### PR TITLE
Allow skipping service principle creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ An opinionated Terraform module that can be used to create and manage an AKS clu
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of the Azure resource group in which to create the AKS cluster. | `string` | n/a | yes |
 | <a name="input_root_disk_size"></a> [root\_disk\_size](#input\_root\_disk\_size) | The size (in GB) of the root disk. | `number` | `100` | no |
 | <a name="input_service_cidr"></a> [service\_cidr](#input\_service\_cidr) | The CIDR block to use for services. | `string` | n/a | yes |
+| <a name="input_sp_enabled"></a> [sp\_enabled](#input\_sp\_enabled) | Set to false to disable service principle creation | `bool` | `true` | no |
 | <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | The ID of the subnet where to place the node pool. | `string` | n/a | yes |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -62,6 +62,7 @@ module "main" {
 
 // Create an Azure AD service principal that Cilium can run under.
 module "cilium_service_principal" {
+  count  = var.sp_enabled == true ? 1 : 0
   source = "git::https://github.com/isovalent/terraform-azure-service-principal.git?ref=v1.1"
 
   application_name = "${var.name}-cilium"

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 output "cilium_service_principal_client_id" {
-  value = module.cilium_service_principal.client_id
+  value = length(module.cilium_service_principal) > 0 ? module.cilium_service_principal[0].client_id : null
 }
 
 output "cilium_service_principal_client_secret" {
-  value = module.cilium_service_principal.client_secret
+  value = length(module.cilium_service_principal) > 0 ? module.cilium_service_principal[0].client_secret : null
 }
 
 output "cluster_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -95,3 +95,9 @@ variable "kube_proxy_disabled" {
   default     = false
   type        = bool
 }
+
+variable "sp_enabled" {
+  description = "Set to false to disable service principle creation"
+  default     = true
+  type        = bool
+}


### PR DESCRIPTION
Service Principal is required for Azure IPAM, which is considered legacy. Allow skipping its creation.