### PR TITLE
vars: set sp_enabled default to false

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ An opinionated Terraform module that can be used to create and manage an AKS clu
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of the Azure resource group in which to create the AKS cluster. | `string` | n/a | yes |
 | <a name="input_root_disk_size"></a> [root\_disk\_size](#input\_root\_disk\_size) | The size (in GB) of the root disk. | `number` | `100` | no |
 | <a name="input_service_cidr"></a> [service\_cidr](#input\_service\_cidr) | The CIDR block to use for services. | `string` | n/a | yes |
-| <a name="input_sp_enabled"></a> [sp\_enabled](#input\_sp\_enabled) | Set to false to disable service principle creation | `bool` | `true` | no |
+| <a name="input_sp_enabled"></a> [sp\_enabled](#input\_sp\_enabled) | Set to false to disable service principle creation | `bool` | `false` | no |
 | <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | The ID of the subnet where to place the node pool. | `string` | n/a | yes |
 | <a name="input_workload_identity_enabled"></a> [workload\_identity\_enabled](#input\_workload\_identity\_enabled) | Enable workload identity | `bool` | `false` | no |
 

--- a/variables.tf
+++ b/variables.tf
@@ -98,7 +98,7 @@ variable "kube_proxy_disabled" {
 
 variable "sp_enabled" {
   description = "Set to false to disable service principle creation"
-  default     = true
+  default     = false
   type        = bool
 }
 


### PR DESCRIPTION
To remove the hard depemdency on service principal reation we set the default value of the
variable `sp_enabled` to false. This allows users
to use the module without creating a service
principal by default.