### PR TITLE
Var: fix admin_azuread_group_names

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ An opinionated Terraform module that can be used to create and manage an AKS clu
 | <a name="input_service_cidr"></a> [service\_cidr](#input\_service\_cidr) | The CIDR block to use for services. | `string` | n/a | yes |
 | <a name="input_sp_enabled"></a> [sp\_enabled](#input\_sp\_enabled) | Set to false to disable service principle creation | `bool` | `false` | no |
 | <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | The ID of the subnet where to place the node pool. | `string` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to assign to the AKS cluster. | `map(string)` | `{}` | no |
 | <a name="input_workload_identity_enabled"></a> [workload\_identity\_enabled](#input\_workload\_identity\_enabled) | Enable workload identity | `bool` | `false` | no |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -55,7 +55,7 @@ module "main" {
   os_disk_size_gb                      = var.root_disk_size
   private_cluster_enabled              = false
   rbac_aad_admin_group_object_ids = [
-    for k, v in data.azuread_group.admins : v.id
+    for k, v in data.azuread_group.admins : split("/", v.id)[2]
   ]
   rbac_aad            = true
   resource_group_name = var.resource_group_name


### PR DESCRIPTION
The AKS module expects a UUID but we're currently
return a path. This commit adds a split
to extract the UUID from the path.