### PR TITLE
Add support for specifying fixed node count and OS SKU

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ An opinionated Terraform module that can be used to create and manage an AKS clu
 | <a name="input_min_nodes"></a> [min\_nodes](#input\_min\_nodes) | The minimum number of nodes in the AKS cluster. | `number` | `3` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name of the AKS cluster. | `string` | n/a | yes |
 | <a name="input_network_plugin"></a> [network\_plugin](#input\_network\_plugin) | The network plugin to use (one of 'azure' or 'none'). | `string` | `"azure"` | no |
+| <a name="input_nodes_count"></a> [nodes\_count](#input\_nodes\_count) | The number of nodes in the AKS cluster when enable\_auto\_scaling = false. Set to null when enable\_auto\_scaling = true | `number` | `2` | no |
 | <a name="input_oidc_issuer_enabled"></a> [oidc\_issuer\_enabled](#input\_oidc\_issuer\_enabled) | Enable OIDC issuer | `bool` | `false` | no |
+| <a name="input_os_sku"></a> [os\_sku](#input\_os\_sku) | (Optional) Specifies the OS SKU used by the agent pool. Possible values include: `Ubuntu`, `CBLMariner`, `Mariner`, `Windows2019`, `Windows2022`. If not specified, the default is `Ubuntu` if OSType=Linux or `Windows2019` if OSType=Windows. And the default Windows OSSKU will be changed to `Windows2022` after Windows2019 is deprecated. Changing this forces a new resource to be created. | `string` | `null` | no |
 | <a name="input_owner"></a> [owner](#input\_owner) | Your name. | `string` | n/a | yes |
 | <a name="input_paid_tier"></a> [paid\_tier](#input\_paid\_tier) | Whether to use the "Standard" AKS tier. | `bool` | `false` | no |
 | <a name="input_public_ssh_key"></a> [public\_ssh\_key](#input\_public\_ssh\_key) | A custom ssh key to control access to the AKS cluster. Changing this forces a new resource to be created. | `string` | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -38,6 +38,7 @@ module "main" {
   location                             = var.region
   agents_max_count                     = var.max_nodes
   agents_min_count                     = var.min_nodes
+  agents_count                         = var.nodes_count
   agents_pool_name                     = local.pool_name
   agents_tags                          = local.tags
   tags                                 = local.tags
@@ -53,6 +54,7 @@ module "main" {
   network_plugin                       = var.network_plugin
   orchestrator_version                 = var.kubernetes_version
   os_disk_size_gb                      = var.root_disk_size
+  os_sku                               = var.os_sku
   private_cluster_enabled              = false
   rbac_aad_admin_group_object_ids = [
     for k, v in data.azuread_group.admins : split("/", v.id)[2]

--- a/variables.tf
+++ b/variables.tf
@@ -47,6 +47,12 @@ variable "min_nodes" {
   type        = number
 }
 
+variable "nodes_count" {
+  default     = 2
+  description = "The number of nodes in the AKS cluster when enable_auto_scaling = false. Set to null when enable_auto_scaling = true"
+  type        = number
+}
+
 variable "network_plugin" {
   description = "The network plugin to use (one of 'azure' or 'none')."
   default     = "azure"
@@ -136,4 +142,10 @@ variable "tags" {
   description = "A map of tags to assign to the AKS cluster."
   type        = map(string)
   default     = {}
+}
+
+variable "os_sku" {
+  type        = string
+  default     = null
+  description = "(Optional) Specifies the OS SKU used by the agent pool. Possible values include: `Ubuntu`, `CBLMariner`, `Mariner`, `Windows2019`, `Windows2022`. If not specified, the default is `Ubuntu` if OSType=Linux or `Windows2019` if OSType=Windows. And the default Windows OSSKU will be changed to `Windows2022` after Windows2019 is deprecated. Changing this forces a new resource to be created."
 }


### PR DESCRIPTION
- Introduced `nodes_count` variable to set the exact number of nodes when autoscaling is disabled
- Added `os_sku` variable to specify the OS SKU for agent pools with default fallback behavior
- Updated the main module to pass `agents_count` and `os_sku` parameters accordingly