### PR TITLE
Expose authorised IP ranges config

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ An opinionated Terraform module that can be used to create and manage an AKS clu
 |------|-------------|------|---------|:--------:|
 | <a name="input_admin_azuread_group_names"></a> [admin\_azuread\_group\_names](#input\_admin\_azuread\_group\_names) | The list of Azure AD groups that should be granted admin access to the AKS cluster. | `list(string)` | `[]` | no |
 | <a name="input_admin_username"></a> [admin\_username](#input\_admin\_username) | The username of the local administrator to be created on the Kubernetes cluster. Set this variable to `null` to turn off the cluster's `linux_profile`. Changing this forces a new resource to be created. | `string` | `null` | no |
+| <a name="input_api_server_authorized_ip_ranges"></a> [api\_server\_authorized\_ip\_ranges](#input\_api\_server\_authorized\_ip\_ranges) | (Optional) The IP ranges to allow for incoming traffic to the server nodes. | `set(string)` | `null` | no |
 | <a name="input_enable_auto_scaling"></a> [enable\_auto\_scaling](#input\_enable\_auto\_scaling) | Enable auto scaling | `bool` | `false` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | The type of instance to use for the single node pool to be created. (NOTE: The upstream AKS module doesn't support multiple node pools yet.) | `string` | `"Standard_D2s_v3"` | no |
 | <a name="input_kube_proxy_disabled"></a> [kube\_proxy\_disabled](#input\_kube\_proxy\_disabled) | Disable kube-proxy | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -41,6 +41,7 @@ module "main" {
   agents_count                         = var.nodes_count
   agents_pool_name                     = local.pool_name
   agents_tags                          = local.tags
+  api_server_authorized_ip_ranges      = var.api_server_authorized_ip_ranges
   tags                                 = local.tags
   agents_size                          = var.instance_type
   cluster_name                         = var.name

--- a/variables.tf
+++ b/variables.tf
@@ -18,6 +18,12 @@ variable "admin_azuread_group_names" {
   type        = list(string)
 }
 
+variable "api_server_authorized_ip_ranges" {
+  type        = set(string)
+  default     = null
+  description = "(Optional) The IP ranges to allow for incoming traffic to the server nodes."
+}
+
 variable "instance_type" {
   default     = "Standard_D2s_v3"
   description = "The type of instance to use for the single node pool to be created. (NOTE: The upstream AKS module doesn't support multiple node pools yet.)"


### PR DESCRIPTION
After Jan 9 25, https://go2.cisco.com/az-public-cloud-exposure was enforced on AKS clusters, causing our existing deployments to fail due to public exposed AKS API without IP range restriction.

This PR adds the necessary config element to our AKS module (is already supported by the underlying Azure AKS module)

Will require either manual config, or use of the Public IP module used in most of our cutes for determining an appropriate value.

See https://isovalent.slack.com/archives/C02RDK98UUR/p1767937727930279